### PR TITLE
优化: 更简单的评价函数计算方法

### DIFF
--- a/evaluation/get_evaluation.py
+++ b/evaluation/get_evaluation.py
@@ -27,12 +27,9 @@ def get_miou_recall_precision(label_image, pred_image, labels):
     precision = {}
     for i in range(r):
         TP = out[i][i]
-        temp = np.concatenate((out[0:i, :], out[i + 1:, :]), axis=0)
-        sum_one = np.sum(temp, axis=0)
-        FP = sum_one[i]
-        temp2 = np.concatenate((out[:, 0:i], out[:, i + 1:]), axis=1)
-        FN = np.sum(temp2, axis=1)[i]
-        TN = temp2.reshape(-1).sum() - FN
+        FP = out[:,i].sum()-TP
+        FN = out[i,:].sum()-TP
+        TN = out.sum()-TP-FP-FN
         iou_temp += (TP / (TP + FP + FN))
         recall[i] = TP / (TP + FN)
         precision[i] = TP / (TP + FP)


### PR DESCRIPTION
第一次PR, 如果有什么不对的地方还请原谅

主要是将评价函数修改成更简单的形式.


```py
if __name__ == '__main__':
    from PIL import Image
    l, p = np.random.randint(0,3,size=(500,100)),np.random.randint(0,3,size=(500,100))
    print(get_miou_recall_precision(l, p, [0, 1, 2]))
    print(l_get_miou_recall_precision(l, p, [0, 1, 2]))

```
可通过上述代码进行正确性的验证.
```
(0.19795873925264684, {0: 0.3282282282282282, 1: 0.32790837854128996, 2: 0.3353221957040573}, {0: 0.3276378896882494, 1: 0.32860163092721234, 2: 0.33522218908440204})
(0.19795873925264684, {0: 0.3282282282282282, 1: 0.32790837854128996, 2: 0.3353221957040573}, {0: 0.3276378896882494, 1: 0.32860163092721234, 2: 0.33522218908440204})
```
输出一致.




